### PR TITLE
Bug fix: fix physical sql template string cache in limit

### DIFF
--- a/polardbx-calcite/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/polardbx-calcite/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -273,7 +273,11 @@ public class SqlSelectOperator extends SqlOperator {
             unparseListClause(writer, select.orderBy);
             writer.endList(orderFrame);
         }
-        writer.fetchOffset(select.fetch, select.offset);
+        if (select.isDynamicFetch()) {
+            writer.fetchOffset(select.computedFetch, select.offset);
+        } else {
+            writer.fetchOffset(select.fetch, select.offset);
+        }
         writer.endList(selectFrame);
     }
 

--- a/polardbx-common/src/main/java/com/alibaba/polardbx/common/properties/ConnectionParams.java
+++ b/polardbx-common/src/main/java/com/alibaba/polardbx/common/properties/ConnectionParams.java
@@ -23,7 +23,6 @@ import com.alibaba.polardbx.common.ddl.newengine.DdlConstants;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class ConnectionParams {
 
     public static final Map<String, ConfigParam> SUPPORTED_PARAMS = new HashMap<>();
@@ -1079,6 +1078,13 @@ public class ConnectionParams {
 
     public static final BooleanConfigParam PLAN_CACHE = new BooleanConfigParam(ConnectionProperties.PLAN_CACHE, true,
         true);
+
+    /**
+     * Physical sql template string cache for external sql
+     */
+    public static final BooleanConfigParam PHY_SQL_TEMPLATE_CACHE =
+        new BooleanConfigParam(ConnectionProperties.PHY_SQL_TEMPLATE_CACHE, true,
+            true);
 
     public static final BooleanConfigParam SKIP_READONLY_CHECK = new BooleanConfigParam(
         ConnectionProperties.SKIP_READONLY_CHECK, false, true);

--- a/polardbx-common/src/main/java/com/alibaba/polardbx/common/properties/ConnectionProperties.java
+++ b/polardbx-common/src/main/java/com/alibaba/polardbx/common/properties/ConnectionProperties.java
@@ -20,6 +20,7 @@ package com.alibaba.polardbx.common.properties;
 public class ConnectionProperties {
 
     public static final String PLAN_CACHE = "PLAN_CACHE";
+    public static final String PHY_SQL_TEMPLATE_CACHE = "PHY_SQL_TEMPLATE_CACHE";
     public static final String PREPARE_OPTIMIZE = "PREPARE_OPTIMIZE";
 
     public static final String ENABLE_RECYCLEBIN = "ENABLE_RECYCLEBIN";

--- a/polardbx-executor/src/main/java/com/alibaba/polardbx/executor/mpp/execution/SessionRepresentation.java
+++ b/polardbx-executor/src/main/java/com/alibaba/polardbx/executor/mpp/execution/SessionRepresentation.java
@@ -369,6 +369,7 @@ public class SessionRepresentation {
         ec.getCacheRelNodeIds().addAll(cacheRelNodesId);
         ec.getRecordRowCnt().putAll(recordRowCnt);
         ec.setInternalSystemSql(false);
+        ec.setUsingPhySqlCache(true);
 
         //mock connection
         MppMockConnection mppMockConnection = new MppMockConnection(user, catalog, schema);

--- a/polardbx-optimizer/src/test/java/com/alibaba/polardbx/planner/common/AdvisorTestCommon.java
+++ b/polardbx-optimizer/src/test/java/com/alibaba/polardbx/planner/common/AdvisorTestCommon.java
@@ -59,6 +59,8 @@ public abstract class AdvisorTestCommon extends PlanTestCommon {
             false);
         final HintPlanner hintPlanner = HintPlanner.getInstance(appName, executionContext);
         executionContext.setInternalSystemSql(false);
+        executionContext.setUsingPhySqlCache(true);
+
         final HintCmdOperator.CmdBean cmdBean = new HintCmdOperator.CmdBean(appName, executionContext.getExtraCmds(),
             executionContext.getGroupHint());
         executionContext.setRandomPhyTableEnabled(false);

--- a/polardbx-optimizer/src/test/java/com/alibaba/polardbx/planner/common/PlanTestCommon.java
+++ b/polardbx-optimizer/src/test/java/com/alibaba/polardbx/planner/common/PlanTestCommon.java
@@ -74,6 +74,8 @@ public abstract class PlanTestCommon extends BasePlannerTest {
         ExecutionContext executionContext = new ExecutionContext();
         final HintPlanner hintPlanner = HintPlanner.getInstance(appName, executionContext);
         executionContext.setInternalSystemSql(false);
+        executionContext.setUsingPhySqlCache(true);
+
         final HintCmdOperator.CmdBean cmdBean = new HintCmdOperator.CmdBean(appName, executionContext.getExtraCmds(),
             executionContext.getGroupHint());
 

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/CobarServer.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/CobarServer.java
@@ -322,6 +322,7 @@ public class CobarServer extends AbstractLifecycle implements Lifecycle {
                 ec.setRecorder(dataSource.getRecorder());
                 ec.setExecutorService(dataSource.borrowExecutorService());
                 ec.setInternalSystemSql(false);
+                ec.setUsingPhySqlCache(true);
                 ec.setExecuteMode(ExecutorMode.MPP);
                 ec.setPrivilegeContext(new MppPrivilegeContext());
                 ec.setTxIsolation(txIsolation);

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/ServerConnection.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/ServerConnection.java
@@ -1194,6 +1194,7 @@ public final class ServerConnection extends FrontendConnection implements Resche
              * system sql of drds
              */
             ec.setInternalSystemSql(false);
+            ec.setUsingPhySqlCache(true);
         }
         ec.setStartTime(System.nanoTime());
         ec.setPrivilegeMode(isPrivilegeMode());


### PR DESCRIPTION
**Problem**: 
Caching physical sql string will lead to storing a SqlLiteral in LogicalView when dealing with queries with `limit`.

**Changes**:
- add computedFetch SqlNode served as a dynamic computed value
- add physical-sql-cache switch in ExecutionContext