### PR TITLE
Import polardbx-rpc (galaxyglue) as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "polardbx-rpc"]
+	path = polardbx-rpc
+	url = git@github.com:ApsaraDB/galaxyglue.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,7 @@ There are many PolarDB-X related repositories, take ApasaraDB GalaxySQL and Apas
 
 ### Create Local Repository
 ```bash
-git clone https://github.com/your_github/galaxysql.git
-cd galaxysql
-git submodule add https://github.com/your_github/galaxyglue.git polardbx-rpc
+git clone --recursive https://github.com/your_github/galaxysql.git
 ```
 ### Create a dev Branch (named as your_github_id_feature_name)
 ```bash

--- a/docs/en/quickstart-development.md
+++ b/docs/en/quickstart-development.md
@@ -89,8 +89,8 @@ export PATH=`pwd`/apache-maven-3.8.3/bin/:$PATH
 # confirm maven version is 3.8.3
 mvn -v
 
-# update subtree
-mv galaxyglue galaxysql/polardbx-rpc
+# make sure polardbx-rpc (galaxyglue) initialized
+git submodule update --init
 
 # enter the galaxysql directory 
 cd galaxysql/

--- a/docs/zh_CN/quickstart-development.md
+++ b/docs/zh_CN/quickstart-development.md
@@ -85,8 +85,8 @@ export PATH=`pwd`/apache-maven-3.8.3/bin/:$PATH
 # 确认Maven版本为3.8.3
 mvn -v
 
-# 移动rpc代码到galaxysql目录下的polardbx-rpc
-mv galaxyglue galaxysql/polardbx-rpc
+# 确保 polardbx-rpc (galaxyglue) 已经初始化
+git submodule update --init
 
 # 进入代码目录 
 cd galaxysql/


### PR DESCRIPTION
As suggested in `CONTRIBUTING.md`, developers need to import `polardbx-rpc` (galaxyglue) as a git submodule manually, so how about checking it into repo?