### PR TITLE
fix: update maven version to fix dead link

### DIFF
--- a/docs/en/quickstart-development.md
+++ b/docs/en/quickstart-development.md
@@ -82,11 +82,11 @@ make install
 # install jdk 1.8, and configure the environment variables JAVA_HOME, PATH
 
 # install maven 3.8
-wget https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
-tar zxvf apache-maven-3.8.3-bin.tar.gz
-export PATH=`pwd`/apache-maven-3.8.3/bin/:$PATH
+wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+tar zxvf apache-maven-3.8.4-bin.tar.gz
+export PATH=`pwd`/apache-maven-3.8.4/bin/:$PATH
 
-# confirm maven version is 3.8.3
+# confirm maven version is 3.8.4
 mvn -v
 
 # update subtree

--- a/docs/zh_CN/quickstart-development.md
+++ b/docs/zh_CN/quickstart-development.md
@@ -78,11 +78,11 @@ make install
 # 安装jdk1.8, 并配置环境变量JAVA_HOME、PATH
 
 # 安装maven3.8
-wget https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
-tar zxvf apache-maven-3.8.3-bin.tar.gz
-export PATH=`pwd`/apache-maven-3.8.3/bin/:$PATH
+wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+tar zxvf apache-maven-3.8.4-bin.tar.gz
+export PATH=`pwd`/apache-maven-3.8.4/bin/:$PATH
 
-# 确认Maven版本为3.8.3
+# 确认Maven版本为3.8.4
 mvn -v
 
 # 移动rpc代码到galaxysql目录下的polardbx-rpc


### PR DESCRIPTION
The hyperlink in development doc is out-of-date (404).

Reference. https://dlcdn.apache.org/maven/maven-3