### PR TITLE
Optimize to be compilable with Java 11

### DIFF
--- a/polardbx-calcite/src/main/java/org/apache/calcite/interpreter/SortNode.java
+++ b/polardbx-calcite/src/main/java/org/apache/calcite/interpreter/SortNode.java
@@ -20,7 +20,6 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rex.RexLiteral;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -87,13 +86,13 @@ public class SortNode extends AbstractSingleNode<Sort> {
     if (rel.getCollation().getFieldCollations().size() == 1) {
       return comparator(rel.getCollation().getFieldCollations().get(0));
     }
-    return Ordering.compound(
-        Iterables.transform(rel.getCollation().getFieldCollations(),
-            new Function<RelFieldCollation, Comparator<? super Row>>() {
-              public Comparator<? super Row> apply(RelFieldCollation input) {
-                return comparator(input);
-              }
-            }));
+
+    // Comparator of lexicographic order.
+    Iterable<Comparator<Row>> comparators = Iterables.transform(
+            rel.getCollation().getFieldCollations(),
+            this::comparator
+    );
+    return Ordering.compound(comparators);
   }
 
   private Comparator<Row> comparator(RelFieldCollation fieldCollation) {

--- a/polardbx-calcite/src/main/java/org/apache/calcite/rel/externalize/RexExplainVisitor.java
+++ b/polardbx-calcite/src/main/java/org/apache/calcite/rel/externalize/RexExplainVisitor.java
@@ -46,11 +46,8 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlPostfixOperator;
 import org.apache.calcite.sql.SqlPrefixOperator;
-import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.fun.SqlCaseOperator;
 import org.apache.calcite.sql.fun.SqlLikeOperator;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.omg.CORBA.OBJ_ADAPTER;
 
 public class RexExplainVisitor implements RexVisitor {
 

--- a/polardbx-common/src/main/java/com/alibaba/polardbx/common/utils/SerializeUtils.java
+++ b/polardbx-common/src/main/java/com/alibaba/polardbx/common/utils/SerializeUtils.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Base64;
 
 @SuppressWarnings("restriction")
 public class SerializeUtils {
@@ -35,14 +36,14 @@ public class SerializeUtils {
         if (s == null) {
             return null;
         }
-        return (new sun.misc.BASE64Encoder()).encode(s.getBytes());
+        return Base64.getEncoder().encodeToString(s.getBytes());
     }
 
     public static String getBase64(byte[] ba) {
         if (ba == null) {
             return null;
         }
-        return (new sun.misc.BASE64Encoder()).encode(ba);
+        return Base64.getEncoder().encodeToString(ba);
     }
 
     public static byte[] base64ToByteArray(String base64) throws IOException {
@@ -50,7 +51,7 @@ public class SerializeUtils {
             return null;
         }
 
-        return (new sun.misc.BASE64Decoder()).decodeBuffer(base64);
+        return Base64.getDecoder().decode(base64);
     }
 
     @SuppressWarnings("unchecked")

--- a/polardbx-gms/src/main/java/com/alibaba/polardbx/gms/util/PasswdUtil.java
+++ b/polardbx-gms/src/main/java/com/alibaba/polardbx/gms/util/PasswdUtil.java
@@ -16,11 +16,10 @@
 
 package com.alibaba.polardbx.gms.util;
 
-import sun.misc.BASE64Decoder;
-import sun.misc.BASE64Encoder;
-
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
+
+import java.util.Base64;
 import java.util.Random;
 
 /**
@@ -45,7 +44,7 @@ public class PasswdUtil {
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");//"算法/模式/补码方式"
             cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
             byte[] encrypted = cipher.doFinal(sSrc.getBytes("utf-8"));
-            return new BASE64Encoder().encode(encrypted);//此处使用BASE64做转码功能，同时能起到2次加密的作用。
+            return Base64.getEncoder().encodeToString(encrypted);//此处使用BASE64做转码功能，同时能起到2次加密的作用。
         } catch (Throwable ex) {
             throw new RuntimeException("param error during encrypt", ex);
         }
@@ -63,7 +62,7 @@ public class PasswdUtil {
             SecretKeySpec skeySpec = new SecretKeySpec(raw, "AES");
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             cipher.init(Cipher.DECRYPT_MODE, skeySpec);
-            byte[] encrypted1 = new BASE64Decoder().decodeBuffer(sSrc);//先用base64解密
+            byte[] encrypted1 = Base64.getDecoder().decode(sSrc);//先用base64解密
             byte[] original = cipher.doFinal(encrypted1);
             String originalString = new String(original, "utf-8");
             return originalString;

--- a/polardbx-net/src/main/java/com/alibaba/polardbx/rpc/cdc/CdcServiceGrpc.java
+++ b/polardbx-net/src/main/java/com/alibaba/polardbx/rpc/cdc/CdcServiceGrpc.java
@@ -28,9 +28,9 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
  */
-@javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.30.0)",
-    comments = "Source: DumperServer.proto")
+// @javax.annotation.Generated(
+//     value = "by gRPC proto compiler (version 1.30.0)",
+//     comments = "Source: DumperServer.proto")
 public final class CdcServiceGrpc {
 
   private CdcServiceGrpc() {}

--- a/polardbx-net/src/main/java/com/alibaba/polardbx/ssl/SslContextFactory.java
+++ b/polardbx-net/src/main/java/com/alibaba/polardbx/ssl/SslContextFactory.java
@@ -25,13 +25,13 @@ import org.apache.commons.lang3.StringUtils;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -40,6 +40,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 
 /**
  * SSL context initialization.
@@ -63,7 +64,11 @@ public final class SslContextFactory {
             if (INIT) {
                 return SERVER_CONTEXT;
             }
-            Security.addProvider(new com.sun.crypto.provider.SunJCE());
+
+            Provider sunjceProvider = Security.getProvider("SUNJCE");
+            if (sunjceProvider != null) {
+                Security.addProvider(sunjceProvider);
+            }
 
             SSLContext serverContext = null;
 
@@ -205,7 +210,7 @@ public final class SslContextFactory {
         String data = new String(pem);
         String[] tokens = data.split(beginDelimiter);
         tokens = tokens[1].split(endDelimiter);
-        return DatatypeConverter.parseBase64Binary(tokens[0]);
+        return Base64.getDecoder().decode(tokens[0]);
     }
 
     protected static RSAPrivateKey generatePrivateKeyFromDER(byte[] keyBytes) throws InvalidKeySpecException,


### PR DESCRIPTION
It has been ~8 years since Oracle first announced GA of the Java 8. I think it's time to move on to a more advanced Java version to improve the development experience as well as to generate more efficient bytecodes. JDK 11 is another LTS version just next to JDK 8 which provides a very important feature:

```java
// Type deduction of local variable.
var s = "123"; // String
```

Great efforts can be saved with this as long as one has a modern IDE (to provide type hint). 

I've tried compiling galaxysql yesterday with OpenJDK 11 but it failed. Further examination shows that most parts of the project are compatible and it shall work with little efforts.

Here're the modifications to make galaxysql compilable and compatible with OpenJDK 11.

1. Remove and replace some of unstable/deprecated/unused APIs, e.g. sun.misc.BASE64Encoder/Decoder are replaced with java.util.Base64
2. Fix a compilation error in generic type deduction.
3. Remove annotation `javax.annotation.Generated`, which is moved to `javax.annotation.processing` package in JDK 11.
    + Generated codes should be provided with original source (.proto file) and method/process to generate, maven grpc plugin in this.
4. Dynamically set SUNJCE as security provider only when it's available.

This PR touches no maven pom files thus it keeps the compatibility with JDK 8. 

Compilation tests have been performed with Oracle JDK 8 and OpenJDK 11. It should be work as expected.