### PR TITLE
fix sort agg exec throw npe

### DIFF
--- a/polardbx-executor/src/main/java/com/alibaba/polardbx/executor/operator/SortAggExec.java
+++ b/polardbx-executor/src/main/java/com/alibaba/polardbx/executor/operator/SortAggExec.java
@@ -79,7 +79,9 @@ public class SortAggExec extends AbstractExecutor {
                     return null;
                 }
                 if (!hasAddToResult) {
-                    buildRow();
+                    if (currentKey != null) {
+                        buildRow();
+                    }
                     hasAddToResult = true;
                 }
                 break;


### PR DESCRIPTION
sort agg exec may throw npe when the input is empty.