### PR TITLE
fix(sec): upgrade snakeyaml to 1.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <stream.version>2.9.5</stream.version>
 <!--        <sum.tools.version>1.8</sum.tools.version>-->
-        <snakeyaml.version>1.19</snakeyaml.version>
+        <snakeyaml.version>1.31</snakeyaml.version>
         <java-ipv6.version>0.17</java-ipv6.version>
 
         <!-- mpp -->


### PR DESCRIPTION
Upgrade snakeyaml from 1.19 to 1.31 for vulnerability fix:
- [CVE-2017-18640](https://www.oscs1024.com/hd/MPS-2019-16129)
- [CVE-2022-25857](https://www.oscs1024.com/hd/MPS-2022-5144)
- [CVE-2022-38751](https://www.oscs1024.com/hd/MPS-2022-56040)

