### PR TITLE
Fix a 'recreate compound primary key' issue.

### DIFF
--- a/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/rel/ddl/LogicalAlterTable.java
+++ b/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/rel/ddl/LogicalAlterTable.java
@@ -1135,6 +1135,7 @@ public class LogicalAlterTable extends LogicalTableOperation {
                 }
             } else if (alterItem instanceof SqlDropPrimaryKey) {
                 primaryKeyDropped = true;
+                droppedIndexes.add("PRIMARY");
             } else if (alterItem instanceof SqlAddPrimaryKey) {
                 SqlAddPrimaryKey addPrimaryKey = (SqlAddPrimaryKey) alterItem;
                 for (SqlIndexColumnName indexColumnName : addPrimaryKey.getColumns()) {

--- a/polardbx-test/src/test/java/com/alibaba/polardbx/qatest/ddl/sharding/ddl/AlterTableTest.java
+++ b/polardbx-test/src/test/java/com/alibaba/polardbx/qatest/ddl/sharding/ddl/AlterTableTest.java
@@ -909,6 +909,33 @@ public class AlterTableTest extends AsyncDDLBaseNewDBTestCase {
     }
 
     @Test
+    public void testAlterTableDropAddCompPrimaryKey() {
+        if (TStringUtil.isNotEmpty(schemaPrefix)) {
+            return;
+        }
+
+        String tableName = "drop_add_comp_pk";
+
+        dropTableIfExists(tableName);
+
+        String sql = "CREATE TABLE " + tableName + " (\n"
+            + "col1 varchar(255) DEFAULT NULL,\n"
+            + "col2 varchar(255) NOT NULL,\n"
+            + "id int(11) NOT NULL AUTO_INCREMENT,\n"
+            + "PRIMARY KEY (id,col2)\n"
+            + ") ENGINE = InnoDB DEFAULT CHARSET = utf8";
+        JdbcUtil.executeUpdateSuccess(tddlConnection, String.format(sql, tableName));
+
+        sql = "ALTER TABLE " + tableName + "\n"
+            + "DROP PRIMARY KEY,\n"
+            + "DROP COLUMN col2,\n"
+            + "ADD PRIMARY KEY (id) USING BTREE";
+        JdbcUtil.executeUpdateSuccess(tddlConnection, String.format(sql, tableName));
+
+        dropTableIfExists(tableName);
+    }
+
+    @Test
     public void testAlterTableDropKey() throws SQLException {
         if (TStringUtil.isNotEmpty(schemaPrefix)) {
             return;


### PR DESCRIPTION
# Problems solved in this PR

Issue #114 

# Changes proposed in this PR

Also hide metadata for dropped primary key before executing physical DDL operations.

# Tests

Added a new test case: AlterTableTest.testAlterTableDropAddCompPrimaryKey()
